### PR TITLE
Fix download url

### DIFF
--- a/pulp_npm/tests/functional/api/test_download_content.py
+++ b/pulp_npm/tests/functional/api/test_download_content.py
@@ -7,7 +7,6 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
 from pulp_smash.pulp3.utils import (
-    download_content_unit,
     gen_distribution,
     gen_repo,
     sync,
@@ -82,7 +81,9 @@ class DownloadContentTestCase(unittest.TestCase):
         ).hexdigest()
 
         # …and Pulp.
-        content = download_content_unit(cfg, distribution, unit_path.split("/")[-1])
-        pulp_hash = hashlib.sha256(content).hexdigest()
-
+        pulp_hash = hashlib.sha256(
+            utils.http_get(
+                urljoin(distribution["base_url"] + "/", unit_path.split("/")[-1])
+            )
+        ).hexdigest()
         self.assertEqual(fixtures_hash, pulp_hash)


### PR DESCRIPTION
pulp_smash is pointing to:
`/pulp/content/74a6afbf-bdb2-48f6-a685-455d9cc2b478/commander-4.0.1.tgz`
when it should point to:
`/pulp_npm/content/74a6afbf-bdb2-48f6-a685-455d9cc2b478/commander-4.0.1.tgz`

Reference: https://github.com/pulp/pulp-smash/pull/1233
