### PR TITLE
Updating nightly to run on push

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,9 @@
 ---
 name: Pulp Nightly CI/CD
 on:
+  push:
+    branches:
+      - master
   schedule:
     # * is a special character in YAML so you have to quote this string
     # runs at 23:00 daily
@@ -15,12 +18,13 @@ on:
 jobs:
   pulp:
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:9.6
-      redis:
-        image: redis
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - TEST: pulp
+          - TEST: docs
+          - TEST: s3
 
     steps:
       - uses: actions/checkout@v2
@@ -64,23 +68,66 @@ jobs:
         run: .github/workflows/scripts/script.sh
         shell: bash
 
-      
+      - name: After failure
+        if: failure()
+        run: |
+          http --timeout 30 --check-status --pretty format --print hb http://pulp/pulp/api/v3/status/ || true
+          docker images || true
+          docker ps -a || true
+          docker logs pulp || true
+          docker exec pulp ls -latr /etc/yum.repos.d/ || true
+          docker exec pulp cat /etc/yum.repos.d/* || true
+
+  deploy:
+    needs: pulp
+    runs-on: ubuntu-latest
+
+    env:
+      TEST: bindings
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # by default, it uses a depth of 1
+          # this fetches all history so that we can read each commit
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: "2.6"
+
+      - name: Install httpie
+        run: |
+          echo ::group::HTTPIE
+          sudo apt-get update -yq
+          sudo -E apt-get -yq --no-install-suggests --no-install-recommends install httpie
+          echo ::endgroup::
+
+      - name: Before Install
+        run: .github/workflows/scripts/before_install.sh
+        shell: bash
+
+      - name: Install
+        run: .github/workflows/scripts/install.sh
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+        shell: bash
+
       - name: Publish nightly client to rubygems
         run: .ci/scripts/publish_client_gem.sh
         shell: bash
-      
 
-      
       - name: Publish nightly client to pypi
         run: .ci/scripts/publish_client_pypi.sh
         shell: bash
-      
 
-      
       - name: Publish nightly docs
         run: .scripts/publish_docs.sh nightly
         shell: bash
-      
 
       - name: After failure
         if: failure()


### PR DESCRIPTION
- We don't have workflows for push, so I added it on nightly
- The deploy only starts after testing pulp, s3 and docs

The DRY approach probably would use:
https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_run
https://github.community/t/details-on-workflow-run/132573

