### PR TITLE
Fix an issue in repo factory remote definition

### DIFF
--- a/pulp_npm/pytest_plugin.py
+++ b/pulp_npm/pytest_plugin.py
@@ -28,6 +28,8 @@ def npm_repository_factory(npm_bindings, gen_object_with_cleanup):
         kwargs = {}
         if pulp_domain:
             kwargs["pulp_domain"] = pulp_domain
+        if remote:
+            body["remote"] = remote if isinstance(remote, str) else remote.pulp_href
         return gen_object_with_cleanup(npm_bindings.RepositoriesNpmApi, body, **kwargs)
 
     return _npm_repository_factory


### PR DESCRIPTION
This commit fixes an issue allowing to define a remote in repo factory fixture. The current implementation is not using the "remote" parameter and trying to set it through kwargs (**body) would conflict with the expected remote (first parameter).