### PR TITLE
[PULP-1003] Add serialized results to tasks

### DIFF
--- a/CHANGES/+fix-task-result.feature
+++ b/CHANGES/+fix-task-result.feature
@@ -1,0 +1,1 @@
+Taught synchronize task to return full serialized object of their action.

--- a/pulp_npm/app/tasks/synchronizing.py
+++ b/pulp_npm/app/tasks/synchronizing.py
@@ -9,6 +9,7 @@ from pulpcore.plugin.stages import (
     DeclarativeVersion,
     Stage,
 )
+from pulpcore.plugin.serializers import RepositoryVersionSerializer
 
 from pulp_npm.app.models import Package, NpmRemote
 
@@ -40,7 +41,9 @@ def synchronize(remote_pk, repository_pk, mirror=False):
     # Interpret policy to download Artifacts or not
     deferred_download = remote.policy != Remote.IMMEDIATE
     first_stage = NpmFirstStage(remote, deferred_download)
-    return DeclarativeVersion(first_stage, repository, mirror=mirror).create()
+    repover = DeclarativeVersion(first_stage, repository, mirror=mirror).create()
+    repover_serialized = RepositoryVersionSerializer(instance=repover, context={"request": None})
+    return repover_serialized
 
 
 class NpmFirstStage(Stage):


### PR DESCRIPTION
Non-serialized task results were deprecated in pulpcore 3.88 and will be removed in pulpcore==3.100

> [!WARNING] 
> The CI's lowerbound scenario requires [this pulpcore PR](https://github.com/pulp/pulpcore/pull/7170) (the 3.49 backport, actually) to be merge **and released**.