### PR TITLE
[PULP-835] Address non-serializable task results deprecation warnings

### DIFF
--- a/CHANGES/354.bugfix
+++ b/CHANGES/354.bugfix
@@ -1,0 +1,1 @@
+Addressed the deprecation warning of non-serializable task results.

--- a/pulp_npm/app/tasks/synchronizing.py
+++ b/pulp_npm/app/tasks/synchronizing.py
@@ -43,7 +43,7 @@ def synchronize(remote_pk, repository_pk, mirror=False):
     first_stage = NpmFirstStage(remote, deferred_download)
     repover = DeclarativeVersion(first_stage, repository, mirror=mirror).create()
     repover_serialized = RepositoryVersionSerializer(instance=repover, context={"request": None})
-    return repover_serialized
+    return repover_serialized.data
 
 
 class NpmFirstStage(Stage):


### PR DESCRIPTION
The issue includes reference to deprecation warnings of legacy STORAGES configuration key and of the use of project.license TOML table, but there is no reference in the codebase or in the CI configuration of the deprecated storage keys and the pyproject.toml doesnt' contain the referenced license table.

The non-use of any license table is consistent with other component's pyproject.py files (e.g, pulpcore and pulp_rpm). This is curious, as I would expect a license field/table in the pyproject for all Pulp components.

Closes #354