### PR TITLE
Fix missing name and version fields in registry metadata version entries

### DIFF
--- a/pulp_npm/app/models.py
+++ b/pulp_npm/app/models.py
@@ -149,6 +149,8 @@ class NpmDistribution(Distribution):
 
             version = {
                 package.version: {
+                    "name": package.name,
+                    "version": package.version,
                     "_id": f"{package.name}@{package.version}",
                     "dist": {"tarball": tarball_url},
                 }


### PR DESCRIPTION
## Summary

- Add `name` and `version` fields to each version entry in `NpmDistribution.content_handler()` registry metadata response

## Problem

The npm registry API expects each version entry to include `name` and `version` fields. Without them:
- **npm** records dependencies as `"npm:null@*"` in `package.json`
- **pnpm** fails with `ERR_PNPM_NO_MATCHING_VERSION`

## Fix

Two-line addition in `pulp_npm/app/models.py`:

```python
version = {
    package.version: {
        "name": package.name,        # added
        "version": package.version,  # added
        "_id": f"{package.name}@{package.version}",
        "dist": {"tarball": tarball_url},
    }
}
```

Fixes #395