### PR TITLE
fix: correctly resolve npm dist-tags latest using semver

### DIFF
--- a/pulp_npm/app/models.py
+++ b/pulp_npm/app/models.py
@@ -1,6 +1,8 @@
 import json
 from logging import getLogger
 
+import semver
+
 from aiohttp.web_response import Response
 from django.conf import settings
 from django.db import models
@@ -155,7 +157,10 @@ class NpmDistribution(Distribution):
             versions.append(package.version)
             data["versions"].update(version)
 
-        data["dist-tags"] = {"latest": max(versions)}
+        parsed = {v: semver.Version.parse(v) for v in versions if semver.Version.is_valid(v)}
+        stable_versions = [v for v, parsed_v in parsed.items() if not parsed_v.prerelease]
+        latest = max(stable_versions, key=parsed.get) if stable_versions else max(parsed, key=parsed.get)
+        data["dist-tags"] = {"latest": latest}
 
         serialized_data = json.dumps(data)
         return Response(body=serialized_data)

--- a/pulp_npm/app/utils.py
+++ b/pulp_npm/app/utils.py
@@ -31,7 +31,7 @@ def extract_package_info(relative_path):
     Args:
         The relative_path string. "package/-/package-version.tgz"
     """
-    pattern = r"^(?P<name>@?[^/]+(?:/[^/]+)?)(?:/-/(?P<base_name>[^/]+)-(?P<version>[\d.]+)\.tgz)?$"
+    pattern = r"^(?P<name>@?[^/]+(?:/[^/]+)?)(?:/-/(?P<base_name>[^/]+?)-(?P<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)\.tgz)?$"
     match = re.match(pattern, relative_path)
 
     if match:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers=[
 requires-python = ">=3.11"
 dependencies = [
   "pulpcore>=3.105.0,<3.130",
+  "semver>=3.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Previously, latest was selected using Python's built-in `max()` on raw version strings, which performs lexicographic comparison (e.g. "9.0.0" > "10.0.0") and did not exclude pre-release versions.

- Replace lexicographic `max(versions)` with `semver.Version.parse` as sort key so that 10.0.0 correctly ranks above 9.0.0
- Filter out pre-release versions (e.g. `1.0.0-alpha.1`) when selecting the `latest` dist-tag; fall back to all versions only if no stable versions exist
- Add `semver>=3.0.0` as a declared runtime dependency in `pyproject.toml`
- Fix `extract_package_info()` regex to match full semver strings including pre-release and build-metadata suffixes, and make the base_name group non-greedy to correctly split hyphenated package names from their version

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added