### PR TITLE
Add package fields to registry metadata version entries

### DIFF
--- a/CHANGES/395.bugfix
+++ b/CHANGES/395.bugfix
@@ -1,0 +1,1 @@
+Added the package name and version to registry metadata version entries.

--- a/pulp_npm/app/models.py
+++ b/pulp_npm/app/models.py
@@ -148,6 +148,8 @@ class NpmDistribution(Distribution):
 
             version = {
                 package.version: {
+                    "name": package.name,
+                    "version": package.version,
                     "_id": f"{package.name}@{package.version}",
                     "dist": {"tarball": tarball_url},
                 }

--- a/pulp_npm/tests/functional/api/test_download_policies.py
+++ b/pulp_npm/tests/functional/api/test_download_policies.py
@@ -57,6 +57,9 @@ def test_sync(
     content_metadata = json.loads(http_get(urljoin(distribution.base_url, "commander")))
 
     latest_version_available = content_metadata["dist-tags"]["latest"]
-    tarball_path = content_metadata["versions"][latest_version_available]["dist"]["tarball"]
+    latest_version = content_metadata["versions"][latest_version_available]
+    assert latest_version["name"] == "commander"
+    assert latest_version["version"] == latest_version_available
+    tarball_path = latest_version["dist"]["tarball"]
 
     http_get(tarball_path)


### PR DESCRIPTION
## Summary

- add `name` and `version` to each registry metadata version entry
- cover the fields in the existing distribution metadata functional test
- add the requested bugfix changelog for #395

This PR supersedes [#396](https://github.com/pulp/pulp_npm/pull/396). The original implementation is credited to HYEONIL SEO in the commit trailer.

Fixes #395

## Validation

- `ruff format --check --diff`
- `ruff check`
- `towncrier build --draft --version 4.0.0.ci`
- `.ci/scripts/validate_commit_message.py HEAD`

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages
- [x] A changelog entry has been added
- [x] Follows the Pulp policy on AI Usage
- [x] Regression test coverage has been added